### PR TITLE
Show staking input in sidebar during confirmation of staking reward

### DIFF
--- a/src/app/classes/walletStatus.ts
+++ b/src/app/classes/walletStatus.ts
@@ -8,6 +8,7 @@ export class WalletStatus {
     errors: string = '';
     latestBlockHeight: number = 0;
     latestBlockTime: number = 0;
+    stake: number = 0;
 }
 
 export enum EncryptionStatus {

--- a/src/app/components/side-bar/side-bar.component.html
+++ b/src/app/components/side-bar/side-bar.component.html
@@ -9,7 +9,7 @@
             <span class="balance-currency">Linda</span>
         </span>
         <!-- Staking -->
-        <h3 *ngIf="wallet.stake">{{ 'COMPONENTS.SIDEBAR.STAKING' | translate | uppercase }}</h3>
+        <h3 *ngIf="wallet.stake" class="stake">{{ 'COMPONENTS.SIDEBAR.STAKING' | translate | uppercase }}</h3>
         <span *ngIf="wallet.stake">
             {{helpers.prettyCoins(wallet.stake)}}
             <span class="balance-currency">Linda</span>

--- a/src/app/components/side-bar/side-bar.component.html
+++ b/src/app/components/side-bar/side-bar.component.html
@@ -9,7 +9,7 @@
             <span class="balance-currency">Linda</span>
         </span>
         <!-- Staking -->
-        <h3 *ngIf="wallet.stake">{{ 'MISC.STAKE' | translate | uppercase }}</h3>
+        <h3 *ngIf="wallet.stake">{{ 'COMPONENTS.SIDEBAR.STAKING' | translate | uppercase }}</h3>
         <span *ngIf="wallet.stake">
             {{helpers.prettyCoins(wallet.stake)}}
             <span class="balance-currency">Linda</span>

--- a/src/app/components/side-bar/side-bar.component.html
+++ b/src/app/components/side-bar/side-bar.component.html
@@ -8,6 +8,12 @@
             {{helpers.prettyCoins(wallet.balance)}}
             <span class="balance-currency">Linda</span>
         </span>
+        <!-- Staking -->
+        <h3 *ngIf="wallet.stake">{{ 'MISC.STAKE' | translate | uppercase }}</h3>
+        <span *ngIf="wallet.stake">
+            {{helpers.prettyCoins(wallet.stake)}}
+            <span class="balance-currency">Linda</span>
+        </span>
         <!-- Menu -->
         <ul routerLinkActive="active">
             <li>

--- a/src/app/providers/wallet.service.ts
+++ b/src/app/providers/wallet.service.ts
@@ -103,6 +103,10 @@ export class WalletService {
         return balance;
     }
 
+    get stake(): Big {
+        return this.walletStatus.stake;
+    }
+
     public requestDataSync(type: DATASYNCTYPES) {
         for (let i = 0; i < this.dataSyncs.length; i++) {
             let dataSync = this.dataSyncs[i];
@@ -201,6 +205,7 @@ export class WalletService {
             this.walletStatus.connections = data.connections;
             this.walletStatus.encryption_status = data.encryption_status;
             this.walletStatus.errors = data.errors;
+            this.walletStatus.stake = data.stake;
 
             if (encryptionChanged) this.encryptionStatusChanges.emit()
         }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -125,7 +125,7 @@ a {
     h3 {
         color: $color-primary;
         font-weight: normal;
-        margin: 0;
+        margin: 10px 0 0 0;
         font-size: 16px;
     }
     .balance-currency {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -125,11 +125,14 @@ a {
     h3 {
         color: $color-primary;
         font-weight: normal;
-        margin: 10px 0 0 0;
+        margin: 0;
         font-size: 16px;
     }
     .balance-currency {
         font-size: 10px;
+    }
+    .stake {
+        padding-top: 10px;
     }
     ul {
         width: 100%;


### PR DESCRIPTION
Requested feature: Show staking input, during confirmation of staking reward input doesn't show under BALANCE
- Hidden when there are no staking rewards
- Becomes visible the when wallet has a staking reward (until it's fully confirmed - then dissapears)
- Added CSS to STAKING label
![capture](https://user-images.githubusercontent.com/38507651/50575119-6be89a80-0df7-11e9-998c-ce5d2e44efa1.PNG)
