### PR TITLE
Fix issues pinging and unenrolling governors

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -337,7 +337,8 @@ export default class Client {
         // set network
         if (this.chain === ChainType.TESTNET) startupCommands.push('-testnet');
         if (this.chain === ChainType.REGTEST) startupCommands.push('-regtest');
-        startupCommands.push('-printtoconsole=0')
+        startupCommands.push('-printtoconsole=0');
+        startupCommands.push('-fallbackfee=10');
         startupCommands = startupCommands.filter(e => e[1] !== '-') // don't send electron specific flags to daemon
         log.info("Client", "Running with commands", startupCommands);
 

--- a/src/app/dgp/providers/dgp.service.ts
+++ b/src/app/dgp/providers/dgp.service.ts
@@ -121,7 +121,7 @@ export class DGPService {
                 let data: any = await this.rpc.requestData(RPCMethods.CALLCONTRACT, [GovernanceContract.ADDRESS, callData]);
                 if (data.executionResult.output.replace(/0/g, '') !== '') {
                     if (!this.governor)
-                        this.governor = new Governor(addressList[i], data);
+                        this.governor = new Governor(govAddr, data);
                     else
                         this.governor.update(data)
                 }


### PR DESCRIPTION
- Our chainfee estimation is not working as a result the sendtocontract command relies on fallbackfee to determine what to use.

- When detecting our governance address we are selecting the index from the wrong array, as a result pings and unenrollment failed.